### PR TITLE
Fix import path for bitcask

### DIFF
--- a/pkg/server.go
+++ b/pkg/server.go
@@ -13,7 +13,7 @@ import (
 	"github.com/HuguesGuilleus/go-db.v1"
 	"github.com/HuguesGuilleus/go-parsersa"
 	"github.com/HuguesGuilleus/static.v2"
-	"github.com/prologic/bitcask"
+	"git.mills.io/prologic/bitcask"
 	"html/template"
 	"log"
 	"net/http"


### PR DESCRIPTION
Project has moved to [git.mills.io/prologic/bitcask](https://git.mills.io/prologic/bitcask).

For details on why see: https://github.com/prologic

Thank you! 🙇